### PR TITLE
Update lv.json licenses

### DIFF
--- a/feeds/lv.json
+++ b/feeds/lv.json
@@ -10,6 +10,9 @@
             "name": "pieturas",
             "type": "http",
             "url": "https://gsvalbe.id.lv/pieturas/dati/latvia.zip",
+            "license": {
+                "spdx_identifier": "CC0-1.0"
+            },
             "fix": true
         },
         {
@@ -17,6 +20,9 @@
             "type": "url",
             "spec": "gtfs-rt",
             "url": "https://gsvalbe.id.lv/pieturas/dati/gtfs-rt.pb"
+            "license": {
+                "spdx_identifier": "CC0-1.0"
+            }
         },
         {
             "name": "B-Bus",


### PR DESCRIPTION
Based on https://data.gov.lv/dati/lv/dataset/?res_format=ZIP&groups=transports and https://gsvalbe.id.lv/pieturas/avoti.html (public data).